### PR TITLE
SG-33057 update pre commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,17 +8,19 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+default_language_version:
+    python: python3
+
 # Styles the code properly
 # Exclude the UI files, as they are auto-generated.
 exclude: "ui\/.*py$"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v5.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
-      language_version: python3
     # Ensures a file name will resolve on all platform
     - id: check-case-conflict
     # Checks files with the execute bit set have shebangs
@@ -35,8 +37,7 @@ repos:
     - id: trailing-whitespace
       exclude: ^resources/
   # Leave black at the bottom so all touchups are done before it is run.
-  - repo: https://github.com/ambv/black
-    rev: 22.3.0
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
     hooks:
     - id: black
-      language_version: python3


### PR DESCRIPTION
Cleanup and update `.pre-commit-config.yaml` file:
- Update pre-commit-hooks to version `v5.0.0`
- Update black hook to version `25.1.0`
- Update black hook URL
- Use global `default_language_version` instead of individuals `language_version`

These changes are optional considering shotgunsoftware/tk-ci-tools#58. But we might want to cleanup/update the `.pre-commit-config.yaml` file every once in a while.